### PR TITLE
Proposing some useful defaults

### DIFF
--- a/cluster-setup/local-cluster/docker-compose.yml
+++ b/cluster-setup/local-cluster/docker-compose.yml
@@ -43,3 +43,24 @@ services:
     links:
       - hadoop-namenode
     tty: true
+  hadoop-datanode2:
+    image: segence/hadoop
+    container_name: hadoop-datanode2
+    hostname: hadoop-datanode2
+    ports:
+      - "8043:8043"
+      - "50076:50076"
+    expose:
+      - "34000-48000"
+      - "50010"
+      - "50020"
+      - "50040"
+    environment:
+      - HDFS_REPLICATION_FACTOR=1
+      - HADOOP_NAMENODE_HOST=hadoop-namenode
+    volumes:
+      - ./data-slave2:/data
+      - ./slaves-config:/config:ro
+    links:
+      - hadoop-namenode
+    tty: true

--- a/cluster-setup/local-cluster/slaves-config/slaves
+++ b/cluster-setup/local-cluster/slaves-config/slaves
@@ -1,1 +1,2 @@
 hadoop-datanode1
+hadoop-datanode2

--- a/docker-container/config/yarn-site.xml
+++ b/docker-container/config/yarn-site.xml
@@ -41,4 +41,16 @@
         <name>yarn.nodemanager.disk-health-checker.max-disk-utilization-per-disk-percentage</name>
         <value>98.5</value>
     </property>
+    <property>
+        <name>yarn.scheduler.minimum-allocation-mb</name>
+        <value>2048</value>
+    </property>
+    <property>
+        <name>yarn.nodemanager.vmem-pmem-ratio</name>
+        <value>2.1</value>
+	</property>
+    <property>
+        <name>yarn.scheduler.minimum-allocation-vcores</name>
+        <value>2</value>
+    </property>
 </configuration>


### PR DESCRIPTION
Hi,

Hope this is not very biased, but having two nodes by defaults makes much more sense for an initial state. Also, added three yarn settings that are useful to do any kind of experimentation by default.

I added the yarn defaults as a base, but usually to get anything done with spark we still need to pump up those minimums (default is 1024M)